### PR TITLE
Fix stream.removeListener may cause unpredictable  effects

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,10 +104,12 @@ module.exports = function(options) {
       var stream = tasks[index];
 
       stream.on('data', writeNewFile);
+      stream.on('end', function() {
+        stream.removeListener('data', writeNewFile);
+      });
       files.forEach(function(file) {
         stream.write(file);
       });
-      stream.removeListener('data', writeNewFile);
     }
 
     if (tasks[++index])


### PR DESCRIPTION
`stream.write` is async operation. you couldn't assume it's already done.