### PR TITLE
fix getBlockType issue with reset lastIndex of jsReg

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ module.exports = function(options) {
   }
 
   function getBlockType(content) {
-    return jsReg.test(content) ? 'js' : 'css';
+    var result = jsReg.test(content) ? 'js' : 'css';
+    jsReg.lastIndex = 0;
+    return result;
   }
 
   function getFiles(content, reg) {


### PR DESCRIPTION
### What
Issue: `getBlockType` function is unstable and returns wrong result sometimes.

### What exactly
This code shows the issue:

```js
var jsReg = /script.+src\s*=\s*['"]([^"']+)['"]/gim
var tests = [];
var str   = "\n  script(src='/js/my-account-requests.js')\n  ";

tests.push( jsReg.test(str) );
tests.push( jsReg.test(str) );
tests.push( jsReg.test(str) );
tests.push( jsReg.test(str) );

console.log(tests); // [ true, false, true, false ]
```

### Why
Problem here is in [`lastIndex` property](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) of regexp with global (`g`) flag.
 
We should either don't use `g` flag or reset `lastIndex` property manually after the each `.test()` and `.exec()` call. Last solution is implemented.